### PR TITLE
Fix error: Can not use managed identity directly in azd compose mode

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,4 +27,4 @@ spring:
         # credential:
         #   managed-identity-enabled: true
         #   client-id: <Client_Id>
-        connection-string: <Connection_String>
+        # connection-string: <Connection_String>


### PR DESCRIPTION
Fix error: Can not use managed identity directly in azd compose mode.